### PR TITLE
コンテナを立ち上げた時にpackage.jsonの内容からパッケージをインストールするようにした

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,4 +17,4 @@ COPY . .
 
 
 # 開発サーバーを起動
-CMD ["/usr/local/bin/node", "/app/node_modules/vite/bin/vite.js", "--host", "0.0.0.0"]
+CMD ["sh", "-c", "npm install && npm run dev"]


### PR DESCRIPTION
# 背景
npmでパッケージを追加する際にコンテナをリビルドした時に毎回コンテナ内でコマンドを叩く必要があった。

# 解決策
コンテナを起動する際にパッケージを自動でインストールするようにした
