### PR TITLE
動画アイテムカード全体を詳細ページへのリンクとして機能させる

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -383,3 +383,11 @@
 .tag-dropdown-item input[type="checkbox"] {
   margin-right: 8px;
 }
+
+.video-item.video-item-card {
+  cursor: pointer;
+}
+
+.video-item.video-item-card:hover {
+  background-color: #3a3a3a; /* A bit lighter for editing mode */
+}

--- a/frontend/src/components/VideoItem.jsx
+++ b/frontend/src/components/VideoItem.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const VideoItem = ({ video, allTags, setAllTags, onUpdateVideo, onDeleteVideo, onEditVideo, isEditing, currentEditData, onCancelEdit, onEditFormChange }) => {
+  const navigate = useNavigate();
+
   const extractVideoId = (url) => {
     const patterns = [
       /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([^&]+)/,
@@ -50,9 +52,22 @@ const VideoItem = ({ video, allTags, setAllTags, onUpdateVideo, onDeleteVideo, o
     onEditFormChange({ ...currentEditData, tags: currentEditData.tags.filter(tag => tag !== tagToRemove) });
   };
 
+  const handleCardClick = (e) => {
+    if (isEditing) return;
+
+    const interactiveElements = ['BUTTON', 'A', 'INPUT', 'SELECT', 'TEXTAREA', 'IFRAME'];
+    if (interactiveElements.includes(e.target.tagName) || e.target.closest('.actions, a')) {
+      return;
+    }
+    navigate(`/video/${video.id}`);
+  };
+
   return (
-    <li className={`video-item ${isEditing ? 'editing' : ''}`}>
-      <strong>Title:</strong> <Link to={`/video/${video.id}`}>{video.title}</Link><br />
+    <li
+      className={`video-item ${isEditing ? 'editing' : 'video-item-card'}`}
+      onClick={handleCardClick}
+    >
+      <strong>Title:</strong> {video.title}<br />
       <strong>Channel:</strong> {video.channel_name}<br />
 
       {isEditing ? (


### PR DESCRIPTION
# やったこと
動画の詳細ページへの遷移が動画のタイトル部分のみに限定されていたため、ユーザーエクスペリエンスを向上させる目的で、動画アイテムカード全体をクリック可能にしました。
- `VideoItem.jsx` に `useNavigate`フックを導入し、プログラムによるナビゲーションを実装。
- 動画タイトルに設定されていた冗長な `<Link>`コンポーネントを削除。
- `<li>`要素にクリックハンドラを追加し、カード内のボタンやリンク、入力フィールドなどのインタラクティブな要素がクリックされた際には詳細ページへの遷移を抑制するロジックを導入。
- `App.css`を更新し、クリック可能な動画アイテムカードに視覚的なフィードバック（ポインターカーソルとホバーエフェクト）を追加。既存のスタイルとの整合性を維持。